### PR TITLE
Change hashbangs to python2

### DIFF
--- a/pack-arbiter2/libexec/check_shinken2.py
+++ b/pack-arbiter2/libexec/check_shinken2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright (C) 2009-2011:
 #    Denis GERMAIN, dt.germain@gmail.com


### PR DESCRIPTION
Using shinken on distributions where Python3 is the default was impossible due to Python2 only compatibility and incorrect hashbangs (`#!/usr/bin/env python`).

By explicitly telling python2 in hashbangs, Shinken still works on systems where there is only python2, and also compatible on systems where there is both Python2 and Python3.

This pull request change the hashbang from `#!/usr/bin/env python` to `#!/usr/bin/env python2`
